### PR TITLE
feat : 내 포인트 조회

### DIFF
--- a/apps/commerce-api/src/main/generated/com/loopers/domain/point/QPointModel.java
+++ b/apps/commerce-api/src/main/generated/com/loopers/domain/point/QPointModel.java
@@ -1,0 +1,53 @@
+package com.loopers.domain.point;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QPointModel is a Querydsl query type for PointModel
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPointModel extends EntityPathBase<PointModel> {
+
+    private static final long serialVersionUID = 1443281032L;
+
+    public static final QPointModel pointModel = new QPointModel("pointModel");
+
+    public final com.loopers.domain.QBaseEntity _super = new com.loopers.domain.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.ZonedDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final DateTimePath<java.time.ZonedDateTime> deletedAt = _super.deletedAt;
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    public final NumberPath<Long> point = createNumber("point", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.ZonedDateTime> updatedAt = _super.updatedAt;
+
+    public final NumberPath<Long> userId = createNumber("userId", Long.class);
+
+    public QPointModel(String variable) {
+        super(PointModel.class, forVariable(variable));
+    }
+
+    public QPointModel(Path<? extends PointModel> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QPointModel(PathMetadata metadata) {
+        super(PointModel.class, metadata);
+    }
+
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
@@ -25,6 +25,15 @@ public class PointFacade {
         PointModel pointModel = pointService.charge(userId, point);
 
         return pointModel.getPoint();
-
     }
+
+    public Long getPointAmount(Long userId){
+
+        if(!userService.existsById(userId)){
+            throw new CoreException(ErrorType.BAD_REQUEST, "존재하지 않는 사용자 입니다.");
+        }
+
+        return pointService.getPointAmount(userId);
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -1,11 +1,9 @@
 package com.loopers.domain.point;
 
 
-import java.util.Optional;
-
 public interface PointRepository {
 
     PointModel save(PointModel pointModel);
 
-    Optional<PointModel> findByUserId(Long userId);
+    PointModel findByUserId(Long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -25,7 +25,9 @@ public class PointService {
 
     }
 
-    public PointModel get(Long userId){
-        return pointRepository.findByUserId(userId);
+    @Transactional(readOnly = true)
+    public Long getPointAmount(Long userId){
+        PointModel pointModel = pointRepository.findByUserId(userId);
+        return pointModel != null? pointModel.getPoint() : null;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -13,14 +13,19 @@ public class PointService {
 
     @Transactional
     public PointModel charge(Long userId, Long point){
-        PointModel pointModel = pointRepository.findByUserId(userId)
-                .orElseGet(() -> pointRepository.save(new PointModel(userId, 0L)));
+        PointModel pointModel = pointRepository.findByUserId(userId);
 
+        if(pointModel == null){
+         pointModel = pointRepository.save(new PointModel(userId, 0L));
+        }
 
         pointModel.charge(point);
 
         return pointRepository.save(pointModel);
 
+    }
 
+    public PointModel get(Long userId){
+        return pointRepository.findByUserId(userId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
@@ -3,9 +3,7 @@ package com.loopers.infrastructure.point;
 import com.loopers.domain.point.PointModel;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface PointJpaRepository extends JpaRepository<PointModel, Long> {
 
-    Optional<PointModel> findByUserId(Long userId);
+    PointModel findByUserId(Long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
@@ -19,7 +19,7 @@ public class PointRepositoryImpl implements PointRepository {
     }
 
     @Override
-    public Optional<PointModel> findByUserId(Long userId) {
+    public PointModel findByUserId(Long userId) {
         return pointJpaRepository.findByUserId(userId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
@@ -8,6 +8,7 @@ import com.loopers.support.error.ErrorType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -111,6 +112,12 @@ public class ApiControllerAdvice {
     public ResponseEntity<ApiResponse<?>> handle(Throwable e) {
         log.error("Exception : {}", e.getMessage(), e);
         return failureResponse(ErrorType.INTERNAL_ERROR, null);
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<ApiResponse<?>> handleMissingRequestHeader(MissingRequestHeaderException ex) {
+        String message = String.format("필수 헤더 누락: " + ex.getHeaderName());
+        return failureResponse(ErrorType.BAD_REQUEST, message);
     }
 
     private String extractMissingParameter(String message) {

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiController.java
@@ -17,4 +17,11 @@ public class PointV1ApiController implements PointV1ApiSpec{
     public ApiResponse<Long> charge(@RequestHeader("X-USER-ID") Long userId, @RequestBody PointV1Dto.PointRequest pointRequest) {
         return ApiResponse.success(pointFacade.charge(userId, pointRequest.point()));
     }
+
+    @Override
+    @GetMapping
+    public ApiResponse<Long> get(@RequestHeader(value = "X-USER-ID") Long userId) {
+
+        return ApiResponse.success(pointFacade.getPointAmount(userId));
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -14,4 +14,9 @@ public interface PointV1ApiSpec {
             @RequestHeader("X-USER-ID") Long userid,
             @RequestBody PointV1Dto.PointRequest pointRequest
     );
+
+    @Operation(summary = "내 포인트 조회")
+    ApiResponse<Long> get(
+            @RequestHeader("X-USER-ID") Long userid
+    );
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/point/PointFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/point/PointFacadeIntegrationTest.java
@@ -12,10 +12,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
-public class PointFacadeIntegrationTest {
+class PointFacadeIntegrationTest {
 
     @Autowired
     private PointFacade pointFacade;
+
 
     @DisplayName("포인트를 충전을 할 때, ")
     @Nested

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -1,0 +1,78 @@
+package com.loopers.domain.point;
+
+import com.loopers.domain.user.UserModel;
+import com.loopers.infrastructure.point.PointJpaRepository;
+import com.loopers.infrastructure.user.UserJpaRepository;
+import com.loopers.interfaces.api.User.Gender;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+class PointServiceIntegrationTest {
+
+    @Autowired
+    private PointService pointService;
+
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private PointJpaRepository pointJpaRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("내 포인트를 조회할 때")
+    @Nested
+    class Get{
+        /**
+         * - [ ]  해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.
+         * - [ ]  해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.
+         */
+
+        @DisplayName("해당 ID의 회원이 존재할 경우, 보유 포인트가 반환된다")
+        @Test
+        void returnsCurrentPoint_whenUserExistsById() {
+            //arrange
+            UserModel signInModel =  new UserModel("testId", Gender.MALE.getCode(), "2024-05-22", "loopers@test.com");
+            userJpaRepository.save(signInModel);
+
+            PointModel pointModel = pointJpaRepository.save(new PointModel(1L, 2000L));
+
+            //act
+            Long result = pointService.getPointAmount(1L);
+
+            //assert
+            assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result).isEqualTo(pointModel.getPoint())
+            );
+        }
+
+        @DisplayName("해당 ID의 회원이 존재하지 않을 경우, null이 반환된다")
+        @Test
+        void returnsNull_whenUserDoesNotExistById() {
+
+            //act
+            Long result = pointService.getPointAmount(1L);
+
+            //assert
+            assertThat(result).isNull();
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
@@ -1,11 +1,13 @@
 package com.loopers.interfaces.api.point;
 
 import com.loopers.domain.point.PointModel;
-import com.loopers.domain.point.PointRepository;
 import com.loopers.domain.user.UserModel;
-import com.loopers.domain.user.UserRepository;
+import com.loopers.infrastructure.point.PointJpaRepository;
+import com.loopers.infrastructure.user.UserJpaRepository;
 import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.interfaces.api.User.Gender;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,15 +23,31 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class PointV1ApiE2ETest {
 
-    @Autowired
-    private TestRestTemplate testRestTemplate;
+    private final TestRestTemplate testRestTemplate;
+
+    private final UserJpaRepository userJpaRepository;
+
+    private final PointJpaRepository pointJpaRepository;
+
+    private final DatabaseCleanUp databaseCleanUp;
 
     @Autowired
-    private UserRepository userRepository;
+    public PointV1ApiE2ETest(
+            TestRestTemplate testRestTemplate,
+            UserJpaRepository userJpaRepository,
+            PointJpaRepository pointJpaRepository,
+            DatabaseCleanUp databaseCleanUp
+    ) {
+        this.testRestTemplate = testRestTemplate;
+        this.userJpaRepository = userJpaRepository;
+        this.pointJpaRepository = pointJpaRepository;
+        this.databaseCleanUp = databaseCleanUp;
+    }
 
-    @Autowired
-    private PointRepository pointRepository;
-
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
     @DisplayName("POST /api/v1/ponits/charge")
     @Nested
     class Charge {
@@ -45,9 +63,9 @@ class PointV1ApiE2ETest {
         void returnsTotalPoint_whenChargingExistingUserWith1000Won(){
             //arrange
             UserModel signInModel =  new UserModel("testId", Gender.MALE.getCode(), "2024-05-22", "loopers@test.com");
-            userRepository.save(signInModel);
+            userJpaRepository.save(signInModel);
 
-            pointRepository.save(new PointModel(1L, 1000L));
+            pointJpaRepository.save(new PointModel(1L, 1000L));
 
             HttpHeaders headers = new HttpHeaders();
             headers.set("X-USER-ID", "1");
@@ -74,6 +92,7 @@ class PointV1ApiE2ETest {
         @Test
         void throwsNotFound_whenChargingNonExistentUser() {
 
+            //arrange
             HttpHeaders headers = new HttpHeaders();
             headers.set("X-USER-ID", "2");
             headers.setContentType(MediaType.APPLICATION_JSON);
@@ -93,6 +112,67 @@ class PointV1ApiE2ETest {
 
         }
 
+
+
+    }
+
+
+    @DisplayName("Get /api/v1/points")
+    @Nested
+    class Get{
+        /**
+         * - [ ]  포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.
+         * - [ ]  `X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다.
+         */
+        private static final String ENDPOINT_GET = "/api/v1/points";
+
+        @DisplayName("포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다")
+        @Test
+        void returnsCurrentPoint_whenUserIdHeaderIsPresent() {
+            //arrange
+            UserModel signInModel =  new UserModel("testId", Gender.MALE.getCode(), "2024-05-22", "loopers@test.com");
+            userJpaRepository.save(signInModel);
+
+            pointJpaRepository.save(new PointModel(1L, 2000L));
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-USER-ID", "1");
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+
+            //act
+            ParameterizedTypeReference<ApiResponse<Long>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<Long>> response =
+                    testRestTemplate.exchange(ENDPOINT_GET, HttpMethod.GET, new HttpEntity<>(headers), responseType);
+
+            //assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().data()).isEqualTo(2000L)
+            );
+        }
+
+        @DisplayName("`X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다")
+        @Test
+        void throwsBadRequestException_whenUserIdHeaderIsMissing() {
+            //arrange
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+
+            //act
+            ParameterizedTypeReference<ApiResponse<Long>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<Long>> response =
+                    testRestTemplate.exchange(ENDPOINT_GET, HttpMethod.GET, new HttpEntity<>(headers), responseType);
+
+            //assert
+//            assertAll(
+//                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST),
+//                    () -> assertThat(response.getBody().meta().result()).isEqualTo(ApiResponse.Metadata.Result.FAIL)
+//            );
+
+        }
 
 
     }

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
@@ -153,6 +153,7 @@ class PointV1ApiE2ETest {
             );
         }
 
+
         @DisplayName("`X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다")
         @Test
         void throwsBadRequestException_whenUserIdHeaderIsMissing() {
@@ -167,10 +168,10 @@ class PointV1ApiE2ETest {
                     testRestTemplate.exchange(ENDPOINT_GET, HttpMethod.GET, new HttpEntity<>(headers), responseType);
 
             //assert
-//            assertAll(
-//                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST),
-//                    () -> assertThat(response.getBody().meta().result()).isEqualTo(ApiResponse.Metadata.Result.FAIL)
-//            );
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST),
+                    () -> assertThat(response.getBody().meta().result()).isEqualTo(ApiResponse.Metadata.Result.FAIL)
+            );
 
         }
 


### PR DESCRIPTION
## 📌 Summary
내 포인트 조회 기능 구현

## 💬 Review Points

    (1) [통합테스트를 서비스 기준으로 생성한 이유]
        api 는 '/api/v1/points' 라서 포인트 객체 전체를 리턴해줘야 할까 고민했습니다.
        하지만 과제 테스트 통과 기준을 보았을때 해당 api는 포인트양(poiintAmount) 를 원하는 요구사항으로 보여졌습니다.
        그래서 맥락을 포인트값만을 리턴한다 라고 생각하고 구현하였습니다.

       구현하면서 포인트 객체는 민감정보이기 때문에 서비스 레이어까지만 알 수 있고 
        facade 에게 '정보 은닉' 을 할 필요가 있다고 판단하여
      서비스를 기준으로 통합테스트를 생성하였습니다.

    (2) ['컨트롤러까지 포인트를 null로 리턴해도 될까'에 대한 고민]
         처음엔 포인트가 존재 하지 않아도 0을 리턴하여야 한다고 생각했습니다.
         하지만, null(포인트기능을 사용한 적 없음)과 0(충전했던 포인트 모두 사용) 으로 볼 수 있기 때문에,
        프론트 영역에서 표현할 수 있는 방식이 달라진다는 생각이 들어 컨트롤러 까지 포인트가 존재하지 않으면 null 을 리턴하였습니다.


## ✅ Checklist

    - [v] 헤더 필수값 누락 시 404 에러 구현
    - [v] 기능 구현
    - [v]  테스트 작성
  
