### PR TITLE
Round 10 Quest 과제 PR 요청

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingViewCriteria.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingViewCriteria.java
@@ -1,5 +1,7 @@
 package com.loopers.application.ranking;
 
+import com.loopers.domain.ranking.RankingCommand;
+
 import java.time.LocalDate;
 
 public class RankingViewCriteria {
@@ -12,4 +14,28 @@ public class RankingViewCriteria {
 
 
     }
+
+    public record SearchWeeklyRanking(
+            int page,
+            int size,
+            LocalDate startDate,
+            LocalDate endDate
+    ){
+        public RankingCommand.SearchWeeklyRanking toCommand(){
+            return new RankingCommand.SearchWeeklyRanking(page, size, startDate, endDate);
+        }
+
+    }
+
+    public record SearchMonthlyRanking(
+            int page,
+            int size,
+            LocalDate startDate,
+            LocalDate endDate
+    ){
+        public RankingCommand.SearchMonthlyRanking toCommand(){
+            return new RankingCommand.SearchMonthlyRanking(page, size, startDate, endDate);
+        }
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingViewFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingViewFacade.java
@@ -6,7 +6,11 @@ import com.loopers.domain.brand.BrandModel;
 import com.loopers.domain.brand.BrandService;
 import com.loopers.domain.product.ProductModel;
 import com.loopers.domain.product.ProductService;
+import com.loopers.domain.ranking.ProductMetricMonthlyModel;
+import com.loopers.domain.ranking.ProductMetricWeeklyModel;
+import com.loopers.domain.ranking.RankingService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Component;
@@ -27,8 +31,9 @@ public class RankingViewFacade {
     private final ProductService productService;
     private final BrandService brandService;
     private final RankingViewCache rankingViewCache;
+    private final RankingService rankingService;
 
-    public RankingViewInfo.ProductList getTodayTopProductsWithCache(RankingViewCriteria.SearchTodayRanking criteria) {
+    public RankingViewInfo.ProductDailyList getTodayTopProductsWithCache(RankingViewCriteria.SearchTodayRanking criteria) {
         // 캐시 계층에 위임
         return rankingViewCache.dailyGetOrLoad(criteria, () -> getTodayTopProducts(criteria));
     }
@@ -36,7 +41,7 @@ public class RankingViewFacade {
     /**
      * 캐시에 없을 때만 실행되는 "로더"
      */
-    public RankingViewInfo.ProductList getTodayTopProducts(RankingViewCriteria.SearchTodayRanking criteria) {
+    public RankingViewInfo.ProductDailyList getTodayTopProducts(RankingViewCriteria.SearchTodayRanking criteria) {
         String key = getKey(criteria.date());
 
         int start = (criteria.page() - 1) * criteria.size();
@@ -78,7 +83,7 @@ public class RankingViewFacade {
                     .toList();
         }
 
-        return new RankingViewInfo.ProductList(
+        return new RankingViewInfo.ProductDailyList(
                 criteria.page(),
                 criteria.size(),
                 criteria.date(),
@@ -88,5 +93,80 @@ public class RankingViewFacade {
 
     private String getKey(LocalDate localDate) {
         return "rank:all:" + localDate;
+    }
+
+    // ✅ 주간
+    public RankingViewInfo.ProductWeeklyList getWeeklyRankingWithPage(RankingViewCriteria.SearchWeeklyRanking criteria) {
+        Page<ProductMetricWeeklyModel> page = rankingService.getWeeklyListWithPage(criteria.toCommand());
+
+        List<RankingViewInfo.Product> products = new ArrayList<>();
+        if (page.hasContent()) {
+            List<ProductModel> productModels = productService.getListByIds(
+                    page.getContent().stream().map(ProductMetricWeeklyModel::getProductId).toList()
+            );
+
+            Map<Long, ProductModel> productMap = toProductMap(productModels);
+            Map<Long, BrandModel> brandMap = toBrandMap(productModels);
+
+            products = page.getContent().stream()
+                    .map(item -> RankingViewInfo.Product.from(
+                            productMap.get(item.getProductId()),
+                            brandMap.getOrDefault(productMap.get(item.getProductId()).getBrandId(), null),
+                            item.getRankValue()
+                    ))
+                    .toList();
+        }
+
+        return new RankingViewInfo.ProductWeeklyList(
+                criteria.page(),
+                criteria.size(),
+                criteria.startDate(),
+                criteria.endDate(),
+                products
+        );
+    }
+
+    // ✅ 월간
+    public RankingViewInfo.ProductMonthlyList getMonthlyRankingWithPage(RankingViewCriteria.SearchMonthlyRanking criteria) {
+        Page<ProductMetricMonthlyModel> page = rankingService.getMonthlyListWithPage(criteria.toCommand());
+
+        List<RankingViewInfo.Product> products = new ArrayList<>();
+        if (page.hasContent()) {
+            List<ProductModel> productModels = productService.getListByIds(
+                    page.getContent().stream().map(ProductMetricMonthlyModel::getProductId).toList()
+            );
+
+            Map<Long, ProductModel> productMap = toProductMap(productModels);
+            Map<Long, BrandModel> brandMap = toBrandMap(productModels);
+
+            products = page.getContent().stream()
+                    .map(item -> RankingViewInfo.Product.from(
+                            productMap.get(item.getProductId()),
+                            brandMap.getOrDefault(productMap.get(item.getProductId()).getBrandId(), null),
+                            item.getRankValue()
+                    ))
+                    .toList();
+        }
+
+        return new RankingViewInfo.ProductMonthlyList(
+                criteria.page(),
+                criteria.size(),
+                criteria.startDate(),
+                criteria.endDate(),
+                products
+        );
+    }
+
+
+    private Map<Long, ProductModel> toProductMap(List<ProductModel> productModels) {
+        return productModels.stream().collect(Collectors.toMap(ProductModel::getId, p -> p));
+    }
+
+    private Map<Long, BrandModel> toBrandMap(List<ProductModel> productModels) {
+        List<Long> brandIds = productModels.stream()
+                .map(ProductModel::getBrandId)
+                .distinct()
+                .toList();
+        return brandService.getBrandMapByIds(brandIds);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingViewInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingViewInfo.java
@@ -12,12 +12,30 @@ import java.util.List;
 public class RankingViewInfo {
 
 
-    public record ProductList(
+    public record ProductDailyList(
             int page,
             int size,
             LocalDate date,
             List<Product> products
     ) implements Serializable {}
+
+    public record ProductWeeklyList(
+            int page,
+            int size,
+            LocalDate startDate,
+            LocalDate endDate,
+            List<Product> products
+    ) implements Serializable {}
+
+    public record ProductMonthlyList(
+            int page,
+            int size,
+            LocalDate startDate,
+            LocalDate endDate,
+            List<Product> products
+    ) implements Serializable {}
+
+
     public record Product(
             int rank,
             Long id,
@@ -43,4 +61,6 @@ public class RankingViewInfo {
             );
         }
     }
+
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingViewRedisConfig.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingViewRedisConfig.java
@@ -11,10 +11,10 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class RankingViewRedisConfig {
 
     @Bean
-    public RedisTemplate<String, RankingViewInfo.ProductList> rankingViewRedisTemplate(
+    public RedisTemplate<String, RankingViewInfo.ProductDailyList> rankingViewRedisTemplate(
             LettuceConnectionFactory defaultRedisConnectionFactory
     ) {
-        RedisTemplate<String, RankingViewInfo.ProductList> template =
+        RedisTemplate<String, RankingViewInfo.ProductDailyList> template =
                 new RedisTemplate<>();
         template.setConnectionFactory(defaultRedisConnectionFactory);
         template.setKeySerializer(new StringRedisSerializer());

--- a/apps/commerce-api/src/main/java/com/loopers/cache/ranking/RankingViewCache.java
+++ b/apps/commerce-api/src/main/java/com/loopers/cache/ranking/RankingViewCache.java
@@ -14,13 +14,13 @@ import java.util.function.Supplier;
 @Service
 public class RankingViewCache {
 
-    private final RedisTemplate<String, RankingViewInfo.ProductList> rankingRedisTemplate;
+    private final RedisTemplate<String, RankingViewInfo.ProductDailyList> rankingRedisTemplate;
 
     private final RankingCachePolicyRegistry policyRegistry;
     private final RankingViewKeyBuilder keyBuilder;
 
     public RankingViewCache(
-            RedisTemplate<String, RankingViewInfo.ProductList> rankingRedisTemplate,
+            RedisTemplate<String, RankingViewInfo.ProductDailyList> rankingRedisTemplate,
             RankingCachePolicyRegistry rankingCachePolicyRegistry,
             RankingViewKeyBuilder rankingViewKeyBuilder
     ){
@@ -31,9 +31,9 @@ public class RankingViewCache {
 
     }
 
-    public RankingViewInfo.ProductList dailyGetOrLoad(
+    public RankingViewInfo.ProductDailyList dailyGetOrLoad(
             RankingViewCriteria.SearchTodayRanking criteria,
-            Supplier<RankingViewInfo.ProductList> loader
+            Supplier<RankingViewInfo.ProductDailyList> loader
     ) {
         RankingType rankingType = RankingType.일일랭킹;
 
@@ -49,7 +49,7 @@ public class RankingViewCache {
         final String key = keyBuilder.build(rankingType, criteria.page(), criteria.size());
 
         // 캐시 조회
-        RankingViewInfo.ProductList cached = rankingRedisTemplate.opsForValue().get(key);
+        RankingViewInfo.ProductDailyList cached = rankingRedisTemplate.opsForValue().get(key);
         if (cached != null) {
             // 남은 TTL 확인
             Long ttl = rankingRedisTemplate.getExpire(key, TimeUnit.SECONDS);
@@ -57,7 +57,7 @@ public class RankingViewCache {
             // refreshAhead 조건 충족 시 비동기 갱신
             if (cachePolicy.shouldRefreshAhead(ttl)) {
                 CompletableFuture.runAsync(() -> {
-                    RankingViewInfo.ProductList refreshed = loader.get();
+                    RankingViewInfo.ProductDailyList refreshed = loader.get();
                     rankingRedisTemplate.opsForValue().set(key, refreshed, cachePolicy.ttl());
                 });
             }
@@ -65,7 +65,7 @@ public class RankingViewCache {
         }
 
         // 없으면 로드 후 캐시에 저장
-        RankingViewInfo.ProductList loaded = loader.get();
+        RankingViewInfo.ProductDailyList loaded = loader.get();
         rankingRedisTemplate.opsForValue().set(key, loaded, cachePolicy.ttl());
         return loaded;
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/ProductMetricMonthlyModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/ProductMetricMonthlyModel.java
@@ -1,0 +1,51 @@
+package com.loopers.domain.ranking;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "product_metric_monthly",
+        uniqueConstraints = @UniqueConstraint(name = "uq_monthly_product", columnNames = {"product_id", "month_start"}))
+public class ProductMetricMonthlyModel {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="product_id", nullable=false)
+    private Long productId;
+    @Column(name="month_start", nullable=false)
+    private LocalDate monthStart;
+    @Column(name="month_end", nullable=false)
+    private LocalDate monthEnd;
+
+    @Column(name="view_count", nullable=false)
+    private long viewCount;
+    @Column(name="like_count", nullable=false)
+    private long likeCount;
+    @Column(name="order_count", nullable=false)
+    private long orderCount;
+
+    @Column(name="score", nullable=false)
+    private long score;
+    @Column(name="rank_value")
+    private Integer rankValue;
+
+    public ProductMetricMonthlyModel(Long productId, LocalDate monthStart, LocalDate monthEnd,
+                                     long viewCount, long likeCount, long orderCount,
+                                     long score, Integer rankValue) {
+        this.productId = productId;
+        this.monthStart= monthStart;
+        this.monthEnd  = monthEnd;
+        this.viewCount = viewCount;
+        this.likeCount = likeCount;
+        this.orderCount= orderCount;
+        this.score     = score;
+        this.rankValue = rankValue;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/ProductMetricMonthlyRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/ProductMetricMonthlyRepository.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.ranking;
+
+
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDate;
+
+public interface ProductMetricMonthlyRepository {
+
+    Page<ProductMetricMonthlyModel> findAllByPaging(int page, int size, LocalDate startDate, LocalDate endDate);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/ProductMetricWeeklyModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/ProductMetricWeeklyModel.java
@@ -1,0 +1,52 @@
+package com.loopers.domain.ranking;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "product_metric_weekly",
+        uniqueConstraints = @UniqueConstraint(name = "uq_weekly_product", columnNames = {"product_id", "week_start"}))
+public class ProductMetricWeeklyModel {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="product_id", nullable=false)
+    private Long productId;
+    @Column(name="week_start", nullable=false)
+    private LocalDate weekStart;
+    @Column(name="week_end", nullable=false)
+    private LocalDate weekEnd;
+
+    @Column(name="view_count",  nullable=false)
+    private long viewCount;
+    @Column(name="like_count",  nullable=false)
+    private long likeCount;
+    @Column(name="order_count", nullable=false)
+    private long orderCount;
+
+    @Column(name="score", nullable=false)
+    private long score;
+    @Column(name="rank_value")
+    private Integer rankValue;
+
+
+    public ProductMetricWeeklyModel(Long productId, LocalDate weekStart, LocalDate weekEnd,
+                                    long viewCount, long likeCount, long orderCount,
+                                    long score, Integer rankValue) {
+        this.productId = productId;
+        this.weekStart = weekStart;
+        this.weekEnd   = weekEnd;
+        this.viewCount = viewCount;
+        this.likeCount = likeCount;
+        this.orderCount= orderCount;
+        this.score     = score;
+        this.rankValue = rankValue;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/ProductMetricWeeklyRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/ProductMetricWeeklyRepository.java
@@ -1,0 +1,12 @@
+package com.loopers.domain.ranking;
+
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDate;
+
+public interface ProductMetricWeeklyRepository {
+
+    Page<ProductMetricWeeklyModel> findAllByPaging( int page, int size, LocalDate startDate, LocalDate endDate);
+
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingCommand.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.ranking;
+
+import java.time.LocalDate;
+
+public class RankingCommand {
+
+    public record SearchWeeklyRanking(
+            int page,
+            int size,
+            LocalDate startDate,
+            LocalDate endDate
+    ){}
+
+    public record SearchMonthlyRanking(
+            int page,
+            int size,
+            LocalDate startDate,
+            LocalDate endDate
+    ){}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -1,0 +1,26 @@
+package com.loopers.domain.ranking;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class RankingService {
+    private final ProductMetricMonthlyRepository productMetricMonthlyRepository;
+    private final ProductMetricWeeklyRepository productMetricWeeklyRepository;
+
+    @Transactional(readOnly = true)
+    public Page<ProductMetricWeeklyModel> getWeeklyListWithPage(RankingCommand.SearchWeeklyRanking command){
+        return productMetricWeeklyRepository.findAllByPaging(command.page(), command.size(), command.startDate(), command.endDate());
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ProductMetricMonthlyModel> getMonthlyListWithPage(RankingCommand.SearchMonthlyRanking command){
+        return productMetricMonthlyRepository.findAllByPaging(command.page(), command.size(), command.startDate(), command.endDate());
+    }
+
+
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/repository/ranking/ProductMetricMonthlyJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/repository/ranking/ProductMetricMonthlyJpaRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.repository.ranking;
+
+
+import com.loopers.domain.ranking.ProductMetricMonthlyModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductMetricMonthlyJpaRepository extends JpaRepository<ProductMetricMonthlyModel, Long> {
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/repository/ranking/ProductMetricMonthlyRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/repository/ranking/ProductMetricMonthlyRepositoryImpl.java
@@ -1,0 +1,51 @@
+package com.loopers.infrastructure.repository.ranking;
+
+import com.loopers.domain.ranking.ProductMetricMonthlyModel;
+import com.loopers.domain.ranking.ProductMetricMonthlyRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.loopers.domain.ranking.QProductMetricMonthlyModel.productMetricMonthlyModel;
+
+@RequiredArgsConstructor
+@Repository
+public class ProductMetricMonthlyRepositoryImpl implements ProductMetricMonthlyRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+
+    @Override
+    public Page<ProductMetricMonthlyModel> findAllByPaging(int page, int size, LocalDate startDate, LocalDate endDate) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+
+        List<ProductMetricMonthlyModel> productMetricMonthlyModels = jpaQueryFactory.selectFrom(productMetricMonthlyModel)
+                .where()
+                .where(
+                        productMetricMonthlyModel.monthStart.eq(startDate),
+                        productMetricMonthlyModel.monthEnd.eq(endDate)
+                )
+                .offset(pageRequest.getOffset())
+                .limit(pageRequest.getPageSize())
+                .fetch()
+                .stream()
+                .toList();
+
+        Long totalCount = jpaQueryFactory.select(productMetricMonthlyModel.count())
+                .from(productMetricMonthlyModel)
+                .where(
+                        productMetricMonthlyModel.monthStart.eq(startDate),
+                        productMetricMonthlyModel.monthEnd.eq(endDate)
+                )
+                .fetchOne();
+
+        long total = totalCount != null ? totalCount : 0L;
+        return new PageImpl<>(productMetricMonthlyModels, pageRequest, total);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/repository/ranking/ProductMetricWeeklyJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/repository/ranking/ProductMetricWeeklyJpaRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.repository.ranking;
+
+import com.loopers.domain.ranking.ProductMetricWeeklyModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface ProductMetricWeeklyJpaRepository extends JpaRepository<ProductMetricWeeklyModel, Long> {
+
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/repository/ranking/ProductMetricWeeklyRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/repository/ranking/ProductMetricWeeklyRepositoryImpl.java
@@ -1,0 +1,51 @@
+package com.loopers.infrastructure.repository.ranking;
+
+
+import com.loopers.domain.ranking.ProductMetricWeeklyModel;
+import com.loopers.domain.ranking.ProductMetricWeeklyRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.loopers.domain.ranking.QProductMetricWeeklyModel.productMetricWeeklyModel;
+
+@RequiredArgsConstructor
+@Repository
+public class ProductMetricWeeklyRepositoryImpl implements ProductMetricWeeklyRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<ProductMetricWeeklyModel> findAllByPaging(int page, int size, LocalDate startDate, LocalDate endDate) {
+
+        PageRequest pageRequest = PageRequest.of(page, size);
+
+        List<ProductMetricWeeklyModel> productMetricWeeklyModelList = jpaQueryFactory.selectFrom(productMetricWeeklyModel)
+                .where(
+                        productMetricWeeklyModel.weekStart.eq(startDate),
+                        productMetricWeeklyModel.weekEnd.eq(endDate)
+                )
+                .offset(pageRequest.getOffset())
+                .limit(pageRequest.getPageSize())
+                .fetch()
+                .stream()
+                .toList();
+
+        Long totalCount = jpaQueryFactory.select(productMetricWeeklyModel.count())
+                .from(productMetricWeeklyModel)
+                .where(
+                        productMetricWeeklyModel.weekStart.eq(startDate),
+                        productMetricWeeklyModel.weekEnd.eq(endDate)
+                )
+                .fetchOne();
+
+        long total = totalCount != null ? totalCount : 0L;
+        return new PageImpl<>(productMetricWeeklyModelList, pageRequest, total);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiController.java
@@ -14,9 +14,19 @@ public class RankingV1ApiController implements RankingV1ApiSpec {
 
     private final RankingViewFacade rankingViewFacade;
     @Override
-    public ApiResponse<RankingViewInfo.ProductList> getTodayRankingList(RankingV1Dto.SearchTodayRankingRequest searchTodayRanking) {
+    public ApiResponse<RankingViewInfo.ProductDailyList> getTodayRankingList(RankingV1Dto.SearchTodayRankingRequest searchTodayRanking) {
 
         return ApiResponse.success(rankingViewFacade.getTodayTopProductsWithCache(searchTodayRanking.toCriteria()));
 
+    }
+
+    @Override
+    public ApiResponse<RankingViewInfo.ProductWeeklyList> getWeeklyRankingList(RankingV1Dto.SearchWeeklyRankingRequest searchWeeklyRankingRequest) {
+        return ApiResponse.success(rankingViewFacade.getWeeklyRankingWithPage(searchWeeklyRankingRequest.toCriteria()));
+    }
+
+    @Override
+    public ApiResponse<RankingViewInfo.ProductMonthlyList> getMonthlyRankingList(RankingV1Dto.SearchMonthlyRankingRequest searchMonthlyRankingRequest) {
+        return ApiResponse.success(rankingViewFacade.getMonthlyRankingWithPage(searchMonthlyRankingRequest.toCriteria()));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -11,8 +11,18 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 @Tag(name = "Ranking V1 API", description = "Ranking API 입니다.")
 public interface RankingV1ApiSpec {
 
-    @Operation(summary = "랭킹조회")
-    ApiResponse<RankingViewInfo.ProductList> getTodayRankingList(
+    @Operation(summary = "일간랭킹조회")
+    ApiResponse<RankingViewInfo.ProductDailyList> getTodayRankingList(
             @Valid @ModelAttribute RankingV1Dto.SearchTodayRankingRequest searchTodayRanking
+    );
+
+    @Operation(summary = "주간랭킹조회")
+    ApiResponse<RankingViewInfo.ProductWeeklyList> getWeeklyRankingList(
+            @Valid @ModelAttribute RankingV1Dto.SearchWeeklyRankingRequest searchWeeklyRankingRequest
+    );
+
+    @Operation(summary = "월간랭킹조회")
+    ApiResponse<RankingViewInfo.ProductMonthlyList> getMonthlyRankingList(
+            @Valid @ModelAttribute RankingV1Dto.SearchMonthlyRankingRequest searchMonthlyRankingRequest
     );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
@@ -2,10 +2,13 @@ package com.loopers.interfaces.api.ranking;
 
 
 import com.loopers.application.ranking.RankingViewCriteria;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 
 public class RankingV1Dto {
 
@@ -20,6 +23,63 @@ public class RankingV1Dto {
         public RankingViewCriteria.SearchTodayRanking toCriteria(){
             LocalDate localDate = LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyyMMdd"));
             return new RankingViewCriteria.SearchTodayRanking(page, size, localDate);
+        }
+    }
+
+
+    public record SearchWeeklyRankingRequest(
+            @NotNull
+            int page,
+            @NotNull
+            int size,
+            @NotNull
+            String startDate,
+            @NotNull
+            String endDate
+
+            ){
+        public RankingViewCriteria.SearchWeeklyRanking toCriteria(){
+            LocalDate startLocalDate = LocalDate.parse(startDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+            LocalDate endLocalDate = LocalDate.parse(endDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+            long days = ChronoUnit.DAYS.between(startLocalDate, endLocalDate) + 1;
+            if (days != 7) {
+                throw new CoreException(
+                        ErrorType.BAD_REQUEST,
+                        "주간 랭킹은 정확히 7일 기간이어야 합니다. (입력된 기간: " + days + "일)"
+                );
+            }
+
+            return new RankingViewCriteria.SearchWeeklyRanking(page, size, startLocalDate, endLocalDate);
+        }
+    }
+
+
+    public record SearchMonthlyRankingRequest(
+            @NotNull
+            int page,
+            @NotNull
+            int size,
+            @NotNull
+            String startDate,
+            @NotNull
+            String endDate
+    ){
+        public RankingViewCriteria.SearchMonthlyRanking toCriteria(){
+            LocalDate startLocalDate = LocalDate.parse(startDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+            LocalDate endLocalDate = LocalDate.parse(endDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+            long days = ChronoUnit.DAYS.between(startLocalDate, endLocalDate) + 1;
+            if (days != 30) {
+                throw new CoreException(
+                        ErrorType.BAD_REQUEST,
+                        "월간 랭킹은 정확히 30일 기간이어야 합니다. (입력된 기간: " + days + "일)"
+                );
+            }
+
+            return new RankingViewCriteria.SearchMonthlyRanking(page, size, startLocalDate, endLocalDate);
         }
     }
 

--- a/apps/commerce-api/src/test/java/com/loopers/application/ranking/RankingViewCacheTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/ranking/RankingViewCacheTest.java
@@ -24,9 +24,9 @@ import static org.mockito.Mockito.*;
 class RankingViewCacheTest {
 
     @Mock
-    private RedisTemplate<String, RankingViewInfo.ProductList> redisTemplate;
+    private RedisTemplate<String, RankingViewInfo.ProductDailyList> redisTemplate;
     @Mock
-    private ValueOperations<String, RankingViewInfo.ProductList> valueOps;
+    private ValueOperations<String, RankingViewInfo.ProductDailyList> valueOps;
     @Mock
     private RankingCachePolicyRegistry policyRegistry;
     @Mock
@@ -41,7 +41,7 @@ class RankingViewCacheTest {
         when(redisTemplate.opsForValue()).thenReturn(valueOps);
     }
 
-    private RankingViewInfo.ProductList dummyList() {
+    private RankingViewInfo.ProductDailyList dummyList() {
         RankingViewInfo.Product product = new RankingViewInfo.Product(
                 1,
                 100L,
@@ -53,7 +53,7 @@ class RankingViewCacheTest {
                 5L,
                 "브랜드A"
         );
-        return new RankingViewInfo.ProductList(
+        return new RankingViewInfo.ProductDailyList(
                 0,
                 20,
                 LocalDate.now(),
@@ -72,10 +72,10 @@ class RankingViewCacheTest {
 
         when(valueOps.get("rank:daily:0:20")).thenReturn(null);
 
-        RankingViewInfo.ProductList expected = dummyList();
-        Supplier<RankingViewInfo.ProductList> loader = () -> expected;
+        RankingViewInfo.ProductDailyList expected = dummyList();
+        Supplier<RankingViewInfo.ProductDailyList> loader = () -> expected;
 
-        RankingViewInfo.ProductList result = rankingViewCache.dailyGetOrLoad(criteria, loader);
+        RankingViewInfo.ProductDailyList result = rankingViewCache.dailyGetOrLoad(criteria, loader);
 
         assertThat(result).isSameAs(expected);
         verify(valueOps).set("rank:daily:0:20", expected, policy.ttl());
@@ -90,13 +90,13 @@ class RankingViewCacheTest {
         when(keyBuilder.build(RankingType.일일랭킹, criteria.page(), criteria.size()))
                 .thenReturn("rank:daily:0:20");
 
-        RankingViewInfo.ProductList cached = dummyList();
+        RankingViewInfo.ProductDailyList cached = dummyList();
         when(valueOps.get("rank:daily:0:20")).thenReturn(cached);
 
         @SuppressWarnings("unchecked")
-        Supplier<RankingViewInfo.ProductList> loader = mock(Supplier.class);
+        Supplier<RankingViewInfo.ProductDailyList> loader = mock(Supplier.class);
 
-        RankingViewInfo.ProductList result = rankingViewCache.dailyGetOrLoad(criteria, loader);
+        RankingViewInfo.ProductDailyList result = rankingViewCache.dailyGetOrLoad(criteria, loader);
 
         assertThat(result).isSameAs(cached);
         verify(loader, never()).get();
@@ -111,17 +111,17 @@ class RankingViewCacheTest {
         when(keyBuilder.build(RankingType.일일랭킹, criteria.page(), criteria.size()))
                 .thenReturn("rank:daily:0:20");
 
-        RankingViewInfo.ProductList cached = dummyList();
+        RankingViewInfo.ProductDailyList cached = dummyList();
         when(valueOps.get("rank:daily:0:20")).thenReturn(cached);
         when(redisTemplate.getExpire("rank:daily:0:20", TimeUnit.SECONDS)).thenReturn(20L); // TTL 20초 남음
 
-        Supplier<RankingViewInfo.ProductList> loader = this::dummyList;
+        Supplier<RankingViewInfo.ProductDailyList> loader = this::dummyList;
 
-        RankingViewInfo.ProductList result = rankingViewCache.dailyGetOrLoad(criteria, loader);
+        RankingViewInfo.ProductDailyList result = rankingViewCache.dailyGetOrLoad(criteria, loader);
 
         assertThat(result).isSameAs(cached);
 
         verify(valueOps, timeout(1000).atLeast(1))
-                .set(eq("rank:daily:0:20"), any(RankingViewInfo.ProductList.class), eq(policy.ttl()));
+                .set(eq("rank:daily:0:20"), any(RankingViewInfo.ProductDailyList.class), eq(policy.ttl()));
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/ranking/RankingViewFacadeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/ranking/RankingViewFacadeTest.java
@@ -4,19 +4,20 @@ import com.loopers.domain.brand.BrandModel;
 import com.loopers.domain.brand.BrandService;
 import com.loopers.domain.product.ProductModel;
 import com.loopers.domain.product.ProductService;
+import com.loopers.domain.ranking.ProductMetricMonthlyModel;
+import com.loopers.domain.ranking.ProductMetricWeeklyModel;
+import com.loopers.domain.ranking.RankingService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 
 import java.time.LocalDate;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -32,6 +33,8 @@ class RankingViewFacadeTest {
     private BrandService brandService;
     @Mock
     private ZSetOperations<String, String> zSetOperations;
+    @Mock
+    private RankingService rankingService;
 
     @InjectMocks
     private RankingViewFacade rankingViewFacade;
@@ -47,26 +50,17 @@ class RankingViewFacadeTest {
 
         when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
 
-        // Redis mock 데이터 (id=1,2,3)
+        // Redis mock 데이터
         Set<ZSetOperations.TypedTuple<String>> rows = new LinkedHashSet<>();
         rows.add(new MockTuple("1", 100.0));
         rows.add(new MockTuple("2", 90.0));
         rows.add(new MockTuple("3", 80.0));
-        when(zSetOperations.reverseRangeWithScores(redisKey, 0, 2))
-                .thenReturn(rows);
+        when(zSetOperations.reverseRangeWithScores(redisKey, 0, 2)).thenReturn(rows);
 
         // Product, Brand mock
-        ProductModel product1 = mock(ProductModel.class);
-        when(product1.getId()).thenReturn(1L);
-        when(product1.getBrandId()).thenReturn(10L);
-
-        ProductModel product2 = mock(ProductModel.class);
-        when(product2.getId()).thenReturn(2L);
-        when(product2.getBrandId()).thenReturn(20L);
-
-        ProductModel product3 = mock(ProductModel.class);
-        when(product3.getId()).thenReturn(3L);
-        when(product3.getBrandId()).thenReturn(30L);
+        ProductModel product1 = mockProduct(1L, 10L);
+        ProductModel product2 = mockProduct(2L, 20L);
+        ProductModel product3 = mockProduct(3L, 30L);
 
         when(productService.getListByIds(List.of(1L, 2L, 3L)))
                 .thenReturn(List.of(product1, product2, product3));
@@ -79,7 +73,7 @@ class RankingViewFacadeTest {
                 ));
 
         // when
-        RankingViewInfo.ProductList result = rankingViewFacade.getTodayTopProducts(criteria);
+        RankingViewInfo.ProductDailyList result = rankingViewFacade.getTodayTopProducts(criteria);
 
         // then
         assertThat(result.products()).hasSize(3);
@@ -91,7 +85,108 @@ class RankingViewFacadeTest {
         verify(brandService).getBrandMapByIds(List.of(10L, 20L, 30L));
     }
 
-    // 간단한 TypedTuple mock 구현체
+    @Test
+    void getWeeklyRankingWithPage_returnsProductsWithRank() {
+        // given
+        LocalDate start = LocalDate.now().minusDays(7);
+        LocalDate end = LocalDate.now();
+        RankingViewCriteria.SearchWeeklyRanking criteria =
+                new RankingViewCriteria.SearchWeeklyRanking(1, 2, start, end);
+
+        ProductMetricWeeklyModel metric1 = mockWeeklyMetric(1L, 1);
+        ProductMetricWeeklyModel metric2 = mockWeeklyMetric(2L, 2);
+
+        when(rankingService.getWeeklyListWithPage(criteria.toCommand()))
+                .thenReturn(new PageImpl<>(List.of(metric1, metric2)));
+
+        ProductModel product1 = mockProduct(1L, 10L);
+        ProductModel product2 = mockProduct(2L, 20L);
+
+        when(productService.getListByIds(List.of(1L, 2L)))
+                .thenReturn(List.of(product1, product2));
+
+        when(brandService.getBrandMapByIds(List.of(10L, 20L)))
+                .thenReturn(Map.of(
+                        10L, mock(BrandModel.class),
+                        20L, mock(BrandModel.class)
+                ));
+
+        // when
+        RankingViewInfo.ProductWeeklyList result = rankingViewFacade.getWeeklyRankingWithPage(criteria);
+
+        // then
+        assertThat(result.products()).hasSize(2);
+        assertThat(result.products().get(0).rank()).isEqualTo(1);
+        assertThat(result.products().get(1).rank()).isEqualTo(2);
+
+        verify(productService).getListByIds(List.of(1L, 2L));
+        verify(brandService).getBrandMapByIds(List.of(10L, 20L));
+    }
+
+    @Test
+    void getMonthlyRankingWithPage_returnsProductsWithRank() {
+        // given
+        LocalDate start = LocalDate.now().minusMonths(1);
+        LocalDate end = LocalDate.now();
+        RankingViewCriteria.SearchMonthlyRanking criteria =
+                new RankingViewCriteria.SearchMonthlyRanking(1, 2, start, end);
+
+        ProductMetricMonthlyModel metric1 = mockMonthlyMetric(3L, 1);
+        ProductMetricMonthlyModel metric2 = mockMonthlyMetric(4L, 2);
+
+        when(rankingService.getMonthlyListWithPage(criteria.toCommand()))
+                .thenReturn(new PageImpl<>(List.of(metric1, metric2)));
+
+        ProductModel product3 = mockProduct(3L, 30L);
+        ProductModel product4 = mockProduct(4L, 40L);
+
+        when(productService.getListByIds(List.of(3L, 4L)))
+                .thenReturn(List.of(product3, product4));
+
+        when(brandService.getBrandMapByIds(List.of(30L, 40L)))
+                .thenReturn(Map.of(
+                        30L, mock(BrandModel.class),
+                        40L, mock(BrandModel.class)
+                ));
+
+        // when
+        RankingViewInfo.ProductMonthlyList result = rankingViewFacade.getMonthlyRankingWithPage(criteria);
+
+        // then
+        assertThat(result.products()).hasSize(2);
+        assertThat(result.products().get(0).rank()).isEqualTo(1);
+        assertThat(result.products().get(1).rank()).isEqualTo(2);
+
+        verify(productService).getListByIds(List.of(3L, 4L));
+        verify(brandService).getBrandMapByIds(List.of(30L, 40L));
+    }
+
+    // ===============================
+    // 헬퍼 메서드 / Mock 클래스
+    // ===============================
+
+    private static ProductModel mockProduct(Long id, Long brandId) {
+        ProductModel product = mock(ProductModel.class);
+        when(product.getId()).thenReturn(id);
+        when(product.getBrandId()).thenReturn(brandId);
+        return product;
+    }
+
+    private static ProductMetricWeeklyModel mockWeeklyMetric(Long productId, int rank) {
+        ProductMetricWeeklyModel metric = mock(ProductMetricWeeklyModel.class);
+        when(metric.getProductId()).thenReturn(productId);
+        when(metric.getRankValue()).thenReturn(rank);
+        return metric;
+    }
+
+    private static ProductMetricMonthlyModel mockMonthlyMetric(Long productId, int rank) {
+        ProductMetricMonthlyModel metric = mock(ProductMetricMonthlyModel.class);
+        when(metric.getProductId()).thenReturn(productId);
+        when(metric.getRankValue()).thenReturn(rank);
+        return metric;
+    }
+
+    // TypedTuple mock 구현체
     static class MockTuple implements ZSetOperations.TypedTuple<String> {
         private final String value;
         private final Double score;

--- a/apps/commerce-batch/build.gradle.kts
+++ b/apps/commerce-batch/build.gradle.kts
@@ -1,0 +1,29 @@
+dependencies {
+    // add-ons
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
+    implementation(project(":supports:jackson"))
+    implementation(project(":supports:logging"))
+    implementation(project(":supports:monitoring"))
+
+    // web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation(project(mapOf("path" to ":apps:commerce-api")))
+
+
+    //batch
+    implementation("org.springframework.boot:spring-boot-starter-batch")
+
+    // querydsl
+    annotationProcessor("com.querydsl:querydsl-apt::jakarta")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
+    testImplementation(testFixtures(project(":modules:kafka")))
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    testImplementation("org.springframework.batch:spring-batch-test")
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/CommerceBatchApplication.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/CommerceBatchApplication.java
@@ -1,0 +1,23 @@
+package com.loopers;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+import java.util.TimeZone;
+
+@ConfigurationPropertiesScan
+@SpringBootApplication
+public class CommerceBatchApplication {
+
+    @PostConstruct
+    public void started() {
+        // set timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(CommerceBatchApplication.class, args);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/MetricPassThroughProcessor.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/MetricPassThroughProcessor.java
@@ -1,0 +1,21 @@
+// src/main/java/com/loopers/config/MetricPassThroughProcessor.java
+package com.loopers.application;
+
+import com.loopers.application.dto.AggregateRow;
+import com.loopers.application.dto.ScoredAggregate;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MetricPassThroughProcessor implements ItemProcessor<AggregateRow, ScoredAggregate> {
+
+    private static final int W_VIEW  = 1;
+    private static final int W_LIKE  = 2;
+    private static final int W_ORDER = 5;
+
+    @Override
+    public ScoredAggregate process(AggregateRow r) {
+        long score = r.viewSum()*W_VIEW + r.likeSum()*W_LIKE + r.orderSum()*W_ORDER;
+        return new ScoredAggregate(r.productId(), r.viewSum(), r.likeSum(), r.orderSum(), score);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/MetricReaders.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/MetricReaders.java
@@ -1,0 +1,70 @@
+package com.loopers.application;
+
+import com.loopers.application.dto.AggregateRow;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+public class MetricReaders {
+
+    private final EntityManagerFactory managerFactory;
+
+    @Bean
+    @StepScope
+    public JpaPagingItemReader<AggregateRow> weeklyReader() {
+        LocalDate start = LocalDate.now().minusDays(7);
+        LocalDate end   = LocalDate.now().minusDays(1);
+
+        return new JpaPagingItemReaderBuilder<AggregateRow>()
+                .name("weeklyReader")
+                .entityManagerFactory(managerFactory)
+                .queryString("""
+                    select new com.loopers.application.dto.AggregateRow(
+                        d.productId,
+                        sum(d.viewCount),
+                        sum(d.likeCount),
+                        sum(d.saleCount)
+                    )
+                    from ProductMetricDailyModel d
+                    where d.date between :start and :end
+                    group by d.productId
+                """)
+                .parameterValues(Map.of("start", start, "end", end))
+                .pageSize(1000)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public JpaPagingItemReader<AggregateRow> monthlyReader() {
+        LocalDate start = LocalDate.now().minusDays(30);
+        LocalDate end   = LocalDate.now().minusDays(1);
+
+        return new JpaPagingItemReaderBuilder<AggregateRow>()
+                .name("monthlyReader")
+                .entityManagerFactory(managerFactory)
+                .queryString("""
+                    select new com.loopers.application.dto.AggregateRow(
+                        d.productId,
+                        sum(d.viewCount),
+                        sum(d.likeCount),
+                        sum(d.saleCount)
+                    )
+                    from ProductMetricDailyModel d
+                    where d.date between :start and :end
+                    group by d.productId
+                """)
+                .parameterValues(Map.of("start", start, "end", end))
+                .pageSize(1000)
+                .build();
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/MonthlyAggregationWriter.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/MonthlyAggregationWriter.java
@@ -1,0 +1,54 @@
+package com.loopers.application;
+
+
+import com.loopers.application.dto.MonthlyUpsertRow;
+import com.loopers.application.dto.ScoredAggregate;
+import com.loopers.domain.metric.ProductMetricMonthlyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MonthlyAggregationWriter implements ItemWriter<ScoredAggregate>, StepExecutionListener {
+
+    private final ProductMetricMonthlyRepository monthlyRepository;
+
+    private LocalDate monthStart;
+    private LocalDate monthEnd;
+
+    private final List<ScoredAggregate> buffer = new ArrayList<>();
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        this.monthStart = LocalDate.now().minusDays(30);
+        this.monthEnd   = LocalDate.now().minusDays(1);
+        buffer.clear();
+    }
+
+    @Override
+    public void write(Chunk<? extends ScoredAggregate> chunk) {
+        buffer.addAll(chunk.getItems());
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        if (!buffer.isEmpty()) {
+            var rows = buffer.stream()
+                    .map(a -> new MonthlyUpsertRow(a.productId(), a.viewSum(), a.likeSum(), a.orderSum(), a.score()))
+                    .toList();
+            monthlyRepository.bulkUpsert(monthStart, monthEnd, rows);
+            monthlyRepository.refreshRanks(monthStart);
+        }
+        return ExitStatus.COMPLETED;
+    }
+}
+

--- a/apps/commerce-batch/src/main/java/com/loopers/application/WeeklyAggregationWriter.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/WeeklyAggregationWriter.java
@@ -1,0 +1,53 @@
+package com.loopers.application;
+
+import com.loopers.application.dto.ScoredAggregate;
+import com.loopers.application.dto.WeeklyUpsertRow;
+import com.loopers.domain.metric.ProductMetricWeeklyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class WeeklyAggregationWriter implements ItemWriter<ScoredAggregate>, StepExecutionListener {
+
+    private final ProductMetricWeeklyRepository weeklyRepository;
+
+    private LocalDate weekStart;
+    private LocalDate weekEnd;
+
+    private final List<ScoredAggregate> buffer = new ArrayList<>();
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        // 필요시 JobParameter로 교체 가능
+        this.weekStart = LocalDate.now().minusDays(7);
+        this.weekEnd   = LocalDate.now().minusDays(1);
+        buffer.clear();
+    }
+
+    @Override
+    public void write(Chunk<? extends ScoredAggregate> chunk) {
+        buffer.addAll(chunk.getItems()); // 청크 모아 일괄 업서트
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        if (!buffer.isEmpty()) {
+            var rows = buffer.stream()
+                    .map(a -> new WeeklyUpsertRow(a.productId(), a.viewSum(), a.likeSum(), a.orderSum(), a.score()))
+                    .toList();
+            weeklyRepository.bulkUpsert(weekStart, weekEnd, rows);
+            weeklyRepository.refreshRanks(weekStart);
+        }
+        return ExitStatus.COMPLETED;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/dto/AggregateRow.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/dto/AggregateRow.java
@@ -1,0 +1,9 @@
+package com.loopers.application.dto;
+
+public record AggregateRow(
+        Long productId,
+        long viewSum,
+        long likeSum,
+        long orderSum
+) {
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/dto/MonthlyUpsertRow.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/dto/MonthlyUpsertRow.java
@@ -1,0 +1,9 @@
+package com.loopers.application.dto;
+public record MonthlyUpsertRow(
+        Long productId,
+        long viewSum,
+        long likeSum,
+        long orderSum,
+        long score
+) {
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/dto/ScoredAggregate.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/dto/ScoredAggregate.java
@@ -1,0 +1,10 @@
+package com.loopers.application.dto;
+
+public record ScoredAggregate(
+        Long productId,
+        long viewSum,
+        long likeSum,
+        long orderSum,
+        long score
+) {
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/dto/WeeklyUpsertRow.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/dto/WeeklyUpsertRow.java
@@ -1,0 +1,9 @@
+package com.loopers.application.dto;
+
+public record WeeklyUpsertRow(
+        Long productId,
+        long viewSum,
+        long likeSum,
+        long orderSum,
+        long score
+) {}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/metric/ProductMetricDailyModel.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/metric/ProductMetricDailyModel.java
@@ -1,0 +1,67 @@
+package com.loopers.domain.metric;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "product_metric_daily",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"product_id", "date"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductMetricDailyModel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long productId;
+
+    private LocalDate date;
+
+    private long likeCount = 0;
+    private long saleCount = 0;
+    private long viewCount = 0;
+
+
+    public ProductMetricDailyModel(Long productId, LocalDate date) {
+        if (productId == null) {
+            throw new IllegalArgumentException("productId must not be null");
+        }
+        if (date == null) {
+            throw new IllegalArgumentException("date must not be null");
+        }
+        this.productId = productId;
+        this.date = date;
+    }
+
+
+    public void updateLikeCount(long delta) {
+        long newValue = this.likeCount + delta;
+        validateNonNegative(newValue, "likeCount");
+        this.likeCount = newValue;
+    }
+
+    public void updateSaleCount(long delta) {
+        long newValue = this.saleCount + delta;
+        validateNonNegative(newValue, "saleCount");
+        this.saleCount = newValue;
+    }
+
+    public void updateViewCount(long delta) {
+        long newValue = this.viewCount + delta;
+        validateNonNegative(newValue, "viewCount");
+        this.viewCount = newValue;
+    }
+
+    // ===== 공통 밸리데이션 =====
+
+    private void validateNonNegative(long newValue, String fieldName) {
+        if (newValue < 0) {
+            throw new IllegalArgumentException(fieldName + " cannot be negative (value=" + newValue + ")");
+        }
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/metric/ProductMetricMonthlyModel.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/metric/ProductMetricMonthlyModel.java
@@ -1,0 +1,51 @@
+package com.loopers.domain.metric;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "product_metric_monthly",
+        uniqueConstraints = @UniqueConstraint(name = "uq_monthly_product", columnNames = {"product_id", "month_start"}))
+public class ProductMetricMonthlyModel {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="product_id", nullable=false)
+    private Long productId;
+    @Column(name="month_start", nullable=false)
+    private LocalDate monthStart;
+    @Column(name="month_end", nullable=false)
+    private LocalDate monthEnd;
+
+    @Column(name="view_count", nullable=false)
+    private long viewCount;
+    @Column(name="like_count", nullable=false)
+    private long likeCount;
+    @Column(name="order_count", nullable=false)
+    private long orderCount;
+
+    @Column(name="score", nullable=false)
+    private long score;
+    @Column(name="rank_value")
+    private Integer rankValue;
+
+    public ProductMetricMonthlyModel(Long productId, LocalDate monthStart, LocalDate monthEnd,
+                                     long viewCount, long likeCount, long orderCount,
+                                     long score, Integer rankValue) {
+        this.productId = productId;
+        this.monthStart= monthStart;
+        this.monthEnd  = monthEnd;
+        this.viewCount = viewCount;
+        this.likeCount = likeCount;
+        this.orderCount= orderCount;
+        this.score     = score;
+        this.rankValue = rankValue;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/metric/ProductMetricMonthlyRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/metric/ProductMetricMonthlyRepository.java
@@ -1,0 +1,17 @@
+package com.loopers.domain.metric;
+
+
+import com.loopers.application.dto.MonthlyUpsertRow;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ProductMetricMonthlyRepository {
+
+    void save(ProductMetricMonthlyModel productMetricMonthlyModel);
+
+    void bulkUpsert(LocalDate monthStart, LocalDate monthEnd, List<MonthlyUpsertRow> rows);
+
+    void refreshRanks(LocalDate monthStart);
+
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/metric/ProductMetricWeeklyModel.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/metric/ProductMetricWeeklyModel.java
@@ -1,0 +1,52 @@
+package com.loopers.domain.metric;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "product_metric_weekly",
+        uniqueConstraints = @UniqueConstraint(name = "uq_weekly_product", columnNames = {"product_id", "week_start"}))
+public class ProductMetricWeeklyModel {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="product_id", nullable=false)
+    private Long productId;
+    @Column(name="week_start", nullable=false)
+    private LocalDate weekStart;
+    @Column(name="week_end", nullable=false)
+    private LocalDate weekEnd;
+
+    @Column(name="view_count",  nullable=false)
+    private long viewCount;
+    @Column(name="like_count",  nullable=false)
+    private long likeCount;
+    @Column(name="order_count", nullable=false)
+    private long orderCount;
+
+    @Column(name="score", nullable=false)
+    private long score;
+    @Column(name="rank_value")
+    private Integer rankValue;
+
+
+    public ProductMetricWeeklyModel(Long productId, LocalDate weekStart, LocalDate weekEnd,
+                                    long viewCount, long likeCount, long orderCount,
+                                    long score, Integer rankValue) {
+        this.productId = productId;
+        this.weekStart = weekStart;
+        this.weekEnd   = weekEnd;
+        this.viewCount = viewCount;
+        this.likeCount = likeCount;
+        this.orderCount= orderCount;
+        this.score     = score;
+        this.rankValue = rankValue;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/metric/ProductMetricWeeklyRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/metric/ProductMetricWeeklyRepository.java
@@ -1,0 +1,17 @@
+package com.loopers.domain.metric;
+
+import com.loopers.application.dto.WeeklyUpsertRow;
+
+import java.time.LocalDate;
+import java.util.List;
+
+
+public interface ProductMetricWeeklyRepository {
+
+    void save(ProductMetricWeeklyModel productMetricWeeklyModel);
+
+    void bulkUpsert(LocalDate weekStart, LocalDate weekEnd, List<WeeklyUpsertRow> rows);
+
+    void refreshRanks(LocalDate weekStart);
+
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ProductMetricDailyJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ProductMetricDailyJpaRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure;
+
+
+import com.loopers.domain.metric.ProductMetricDailyModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductMetricDailyJpaRepository extends JpaRepository<ProductMetricDailyModel, Long> {
+
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ProductMetricMonthlyJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ProductMetricMonthlyJpaRepository.java
@@ -1,0 +1,24 @@
+package com.loopers.infrastructure;
+
+
+import com.loopers.domain.metric.ProductMetricMonthlyModel;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+
+public interface ProductMetricMonthlyJpaRepository extends JpaRepository<ProductMetricMonthlyModel, Long> {
+
+    @Modifying
+    @Query(value = """
+        UPDATE product_metric_monthly mm
+        JOIN (
+          SELECT product_id, DENSE_RANK() OVER (ORDER BY score DESC) AS rnk
+          FROM product_metric_monthly
+          WHERE month_start = :monthStart
+        ) x ON x.product_id = mm.product_id
+        SET mm.rank_value = x.rnk
+        WHERE mm.month_start = :monthStart
+        """, nativeQuery = true)
+    void refreshRanks(@Param("monthStart") LocalDate monthStart);
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ProductMetricMonthlyRepositoryImpl.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ProductMetricMonthlyRepositoryImpl.java
@@ -1,0 +1,68 @@
+package com.loopers.infrastructure;
+
+import com.loopers.application.dto.MonthlyUpsertRow;
+import com.loopers.domain.metric.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class ProductMetricMonthlyRepositoryImpl implements ProductMetricMonthlyRepository {
+
+    private final ProductMetricMonthlyJpaRepository productMetricMonthlyJpaRepository;
+    private final JdbcTemplate jdbc; // 업서트는 JDBC 배치로 처리
+
+    // 기존 save를 꼭 써야 하는 곳이 있다면 유지
+    @Override
+    public void save(ProductMetricMonthlyModel model) {
+        productMetricMonthlyJpaRepository.save(model);
+    }
+
+    @Override
+    @Transactional
+    public void bulkUpsert(LocalDate monthStart, LocalDate monthEnd, List<MonthlyUpsertRow> rows) {
+        if (rows == null || rows.isEmpty()) return;
+
+        final String sql = """
+            INSERT INTO product_metric_monthly
+              (product_id, month_start, month_end, view_count, like_count, order_count, score, rank_value)
+            VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
+            ON DUPLICATE KEY UPDATE
+              month_end   = VALUES(month_end),
+              view_count  = VALUES(view_count),
+              like_count  = VALUES(like_count),
+              order_count = VALUES(order_count),
+              score       = VALUES(score),
+              rank_value  = NULL
+            """;
+
+        jdbc.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                MonthlyUpsertRow r = rows.get(i);
+                ps.setLong(1, r.productId());
+                ps.setObject(2, monthStart);
+                ps.setObject(3, monthEnd);
+                ps.setLong(4, r.viewSum());
+                ps.setLong(5, r.likeSum());
+                ps.setLong(6, r.orderSum());
+                ps.setLong(7, r.score());
+            }
+            @Override public int getBatchSize() { return rows.size(); }
+        });
+    }
+
+    @Override
+    @Transactional
+    public void refreshRanks(LocalDate monthStart) {
+        productMetricMonthlyJpaRepository.refreshRanks(monthStart);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ProductMetricWeeklyJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ProductMetricWeeklyJpaRepository.java
@@ -1,0 +1,27 @@
+package com.loopers.infrastructure;
+
+import com.loopers.domain.metric.ProductMetricWeeklyModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+
+
+public interface ProductMetricWeeklyJpaRepository extends JpaRepository<ProductMetricWeeklyModel, Long> {
+
+    @Modifying
+    @Query(value = """
+        UPDATE product_metric_weekly wm
+        JOIN (
+          SELECT product_id, DENSE_RANK() OVER (ORDER BY score DESC) AS rnk
+          FROM product_metric_weekly
+          WHERE week_start = :weekStart
+        ) x ON x.product_id = wm.product_id
+        SET wm.rank_value = x.rnk
+        WHERE wm.week_start = :weekStart
+        """, nativeQuery = true)
+    void refreshRanks(@Param("weekStart") LocalDate weekStart);
+
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ProductMetricWeeklyRepositoryImpl.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ProductMetricWeeklyRepositoryImpl.java
@@ -1,0 +1,68 @@
+package com.loopers.infrastructure;
+
+
+import com.loopers.domain.metric.ProductMetricWeeklyModel;
+import com.loopers.domain.metric.ProductMetricWeeklyRepository;
+import com.loopers.application.dto.WeeklyUpsertRow;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class ProductMetricWeeklyRepositoryImpl implements ProductMetricWeeklyRepository {
+
+    private final ProductMetricWeeklyJpaRepository productMetricWeeklyJpaRepository;
+    private final JdbcTemplate jdbc;
+
+    @Override
+    public void save(ProductMetricWeeklyModel productMetricWeeklyModel) {
+        productMetricWeeklyJpaRepository.save(productMetricWeeklyModel);
+    }
+
+    @Override
+    @Transactional
+    public void bulkUpsert(LocalDate weekStart, LocalDate weekEnd, List<WeeklyUpsertRow> rows) {
+        if (rows == null || rows.isEmpty()) return;
+
+        final String sql = """
+            INSERT INTO product_metric_weekly
+              (product_id, week_start, week_end, view_count, like_count, order_count, score, rank_value)
+            VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
+            ON DUPLICATE KEY UPDATE
+              week_end   = VALUES(week_end),
+              view_count = VALUES(view_count),
+              like_count = VALUES(like_count),
+              order_count= VALUES(order_count),
+              score      = VALUES(score),
+              rank_value = NULL
+            """;
+
+        jdbc.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override public void setValues(PreparedStatement ps, int i) throws SQLException {
+                WeeklyUpsertRow r = rows.get(i);
+                ps.setLong(1, r.productId());
+                ps.setObject(2, weekStart); // JDBC 4.2: LocalDate OK
+                ps.setObject(3, weekEnd);
+                ps.setLong(4, r.viewSum());
+                ps.setLong(5, r.likeSum());
+                ps.setLong(6, r.orderSum());
+                ps.setLong(7, r.score());
+            }
+            @Override public int getBatchSize() { return rows.size(); }
+        });
+    }
+
+    @Override
+    @Transactional
+    public void refreshRanks(LocalDate weekStart) {
+        productMetricWeeklyJpaRepository.refreshRanks(weekStart);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/job/MetricAggregationJobConfig.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/job/MetricAggregationJobConfig.java
@@ -1,0 +1,59 @@
+package com.loopers.infrastructure.job;
+
+import com.loopers.application.MetricReaders;
+import com.loopers.application.MonthlyAggregationWriter;
+import com.loopers.application.WeeklyAggregationWriter;
+import com.loopers.application.MetricPassThroughProcessor;
+import com.loopers.application.dto.AggregateRow;
+import com.loopers.application.dto.ScoredAggregate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class MetricAggregationJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager txManager;
+
+    private final MetricPassThroughProcessor processor;
+    private final WeeklyAggregationWriter weeklyWriter;
+    private final MonthlyAggregationWriter monthlyWriter;
+
+    private final MetricReaders readers;
+
+    @Bean
+    public Step weeklyStep() {
+        return new StepBuilder("weeklyStep", jobRepository)
+                .<AggregateRow, ScoredAggregate>chunk(1000, txManager)
+                .reader(readers.weeklyReader())
+                .processor(processor)
+                .writer(weeklyWriter)
+                .build();
+    }
+
+    @Bean
+    public Step monthlyStep() {
+        return new StepBuilder("monthlyStep", jobRepository)
+                .<AggregateRow, ScoredAggregate>chunk(1000, txManager)
+                .reader(readers.monthlyReader())
+                .processor(processor)
+                .writer(monthlyWriter)
+                .build();
+    }
+
+    @Bean
+    public Job metricAggregationJob(Step weeklyStep, Step monthlyStep) {
+        return new JobBuilder("metricAggregationJob", jobRepository)
+                .start(weeklyStep)
+                .next(monthlyStep)
+                .build();
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/interfaces/scheduler/MetricJobScheduler.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/interfaces/scheduler/MetricJobScheduler.java
@@ -1,0 +1,29 @@
+package com.loopers.interfaces.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Configuration
+@EnableScheduling
+@RequiredArgsConstructor
+public class MetricJobScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job metricAggregationJob;
+
+    // 매일 새벽 1시 실행 (주간/월간 집계 동시에 처리)
+    @Scheduled(cron = "0 0 1 * * ?")
+    public void runMetricAggregationJob() throws Exception {
+        JobParameters params = new JobParametersBuilder()
+                .addLong("timestamp", System.currentTimeMillis())
+                .toJobParameters();
+
+        jobLauncher.run(metricAggregationJob, params);
+    }
+}

--- a/apps/commerce-batch/src/main/resources/application.yml
+++ b/apps/commerce-batch/src/main/resources/application.yml
@@ -1,0 +1,57 @@
+server:
+  shutdown: graceful
+  port: 8086   # web=false이면 의미 없음
+
+spring:
+  main:
+    web-application-type: none   # 톰캣 안 띄움
+  application:
+    name: commerce-batch
+  profiles:
+    active: local
+  config:
+    import:
+      - jpa.yml
+      - redis.yml
+      - logging.yml
+      - monitoring.yml
+  batch:
+    job:
+      enabled: false     # 기동 시 자동 실행 방지
+    jdbc:
+      initialize-schema: never  # MySQL은 수동 생성 필요
+
+---
+
+spring.config.activate.on-profile: test
+
+spring:
+  batch:
+    jdbc:
+      initialize-schema: always
+
+datasource:
+  redis:
+    enabled: false
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  batch:
+    jdbc:
+      initialize-schema: always
+    job:
+      enabled: true
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/apps/commerce-batch/src/test/java/com/loopers/CommerceBatchContextTest.java
+++ b/apps/commerce-batch/src/test/java/com/loopers/CommerceBatchContextTest.java
@@ -1,0 +1,14 @@
+package com.loopers;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CommerceBatchContextTest {
+
+    @Test
+    void contextLoads() {
+        // 이 테스트는 Spring Boot 애플리케이션 컨텍스트가 로드되는지 확인합니다.
+        // 모든 빈이 올바르게 로드되었는지 확인하는 데 사용됩니다.
+    }
+}

--- a/apps/commerce-batch/src/test/java/com/loopers/application/MetricPassThroughProcessorTest.java
+++ b/apps/commerce-batch/src/test/java/com/loopers/application/MetricPassThroughProcessorTest.java
@@ -1,0 +1,33 @@
+package com.loopers.application;
+
+
+import com.loopers.application.dto.AggregateRow;
+import com.loopers.application.dto.ScoredAggregate;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class MetricPassThroughProcessorTest {
+
+    private final MetricPassThroughProcessor sut = new MetricPassThroughProcessor();
+
+    @Test
+    void score_is_calculated_with_weights_1_2_5() throws Exception {
+        // given
+
+        AggregateRow row = new AggregateRow(10L, 100, 20, 3);
+
+        // when
+        ScoredAggregate out = sut.process(row);
+
+        // then
+        // score = 100*1 + 20*2 + 3*5 = 100 + 40 + 15 = 155
+        assertNotNull(out);
+        assertEquals(10L, out.productId());
+        assertEquals(100, out.viewSum());
+        assertEquals(20, out.likeSum());
+        assertEquals(3, out.orderSum());
+        assertEquals(155, out.score());
+    }
+}

--- a/apps/commerce-batch/src/test/java/com/loopers/application/MonthlyAggregationWriterTest.java
+++ b/apps/commerce-batch/src/test/java/com/loopers/application/MonthlyAggregationWriterTest.java
@@ -1,0 +1,55 @@
+package com.loopers.application;
+
+import com.loopers.application.dto.ScoredAggregate;
+import com.loopers.domain.metric.ProductMetricMonthlyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.item.Chunk;
+
+import java.time.LocalDate;
+
+import static org.mockito.Mockito.*;
+
+class MonthlyAggregationWriterTest {
+
+    private ProductMetricMonthlyRepository monthlyRepository;
+    private MonthlyAggregationWriter writer;
+
+    @BeforeEach
+    void setUp() {
+        monthlyRepository = mock(ProductMetricMonthlyRepository.class);
+        writer = new MonthlyAggregationWriter(monthlyRepository);
+    }
+
+    @Test
+    void writer_buffers_items_and_flushes_on_afterStep() {
+        // given
+        ScoredAggregate a1 = new ScoredAggregate(1L, 10, 5, 2, 10*1 + 5*2 + 2*5);
+        ScoredAggregate a2 = new ScoredAggregate(2L, 3, 1, 1, 3*1 + 1*2 + 1*5);
+
+        writer.beforeStep(null);
+
+        // when
+        writer.write(Chunk.of(a1, a2));
+        writer.afterStep(null);
+
+        // then
+        verify(monthlyRepository, times(1))
+                .bulkUpsert(any(LocalDate.class), any(LocalDate.class), anyList());
+        verify(monthlyRepository, times(1))
+                .refreshRanks(any(LocalDate.class));
+    }
+
+    @Test
+    void writer_does_not_call_repository_when_buffer_is_empty() {
+        // given
+        writer.beforeStep(null);
+
+        // when
+        writer.afterStep(null);
+
+        // then
+        verify(monthlyRepository, never()).bulkUpsert(any(), any(), anyList());
+        verify(monthlyRepository, never()).refreshRanks(any());
+    }
+}

--- a/apps/commerce-batch/src/test/java/com/loopers/application/ReaderJpaQueryTest.java
+++ b/apps/commerce-batch/src/test/java/com/loopers/application/ReaderJpaQueryTest.java
@@ -1,0 +1,69 @@
+package com.loopers.application;
+
+import com.loopers.application.dto.AggregateRow;
+import com.loopers.domain.metric.ProductMetricDailyModel;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@EntityScan(basePackages = "com.loopers.domain.metric")
+@Transactional
+class ReaderJpaQueryTest {
+
+    @PersistenceContext
+    EntityManager em;
+
+    @Test
+    void groupBy_query_returns_aggregated_rows() {
+        // given: 일간 raw 데이터 적재
+        LocalDate d1 = LocalDate.of(2025, 9, 10);
+        LocalDate d2 = LocalDate.of(2025, 9, 11);
+
+        ProductMetricDailyModel a = new ProductMetricDailyModel(1L, d1);
+        a.updateViewCount(10); a.updateLikeCount(2); a.updateSaleCount(1);
+        em.persist(a);
+
+        ProductMetricDailyModel b = new ProductMetricDailyModel(1L, d2);
+        b.updateViewCount(5); b.updateLikeCount(1); b.updateSaleCount(0);
+        em.persist(b);
+
+        ProductMetricDailyModel c = new ProductMetricDailyModel(2L, d1);
+        c.updateViewCount(20); c.updateLikeCount(0); c.updateSaleCount(0);
+        em.persist(c);
+
+        em.flush(); em.clear();
+
+        // when: 동일 JPQL 실행
+        List<AggregateRow> rows = em.createQuery("""
+                select new com.loopers.application.dto.AggregateRow(
+                    d.productId,
+                    sum(d.viewCount),
+                    sum(d.likeCount),
+                    sum(d.saleCount)
+                )
+                from ProductMetricDailyModel d
+                where d.date between :start and :end
+                group by d.productId
+                """, AggregateRow.class)
+                .setParameter("start", d1)
+                .setParameter("end",   d2)
+                .getResultList();
+
+        // then
+        assertEquals(2, rows.size());
+        var r1 = rows.stream().filter(r -> r.productId().equals(1L)).findFirst().orElseThrow();
+        assertEquals(15, r1.viewSum()); // 10 + 5
+        assertEquals(3,  r1.likeSum()); // 2 + 1
+        assertEquals(1,  r1.orderSum()); // 1 + 0
+    }
+}
+

--- a/apps/commerce-batch/src/test/java/com/loopers/application/WeeklyAggregationWriterTest.java
+++ b/apps/commerce-batch/src/test/java/com/loopers/application/WeeklyAggregationWriterTest.java
@@ -1,0 +1,55 @@
+package com.loopers.application;
+
+import com.loopers.application.dto.ScoredAggregate;
+import com.loopers.domain.metric.ProductMetricWeeklyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.item.Chunk;
+
+import java.time.LocalDate;
+
+import static org.mockito.Mockito.*;
+
+class WeeklyAggregationWriterTest {
+
+    private ProductMetricWeeklyRepository weeklyRepository;
+    private WeeklyAggregationWriter writer;
+
+    @BeforeEach
+    void setUp() {
+        weeklyRepository = mock(ProductMetricWeeklyRepository.class);
+        writer = new WeeklyAggregationWriter(weeklyRepository);
+    }
+
+    @Test
+    void writer_buffers_items_and_flushes_on_afterStep() {
+        // given
+        ScoredAggregate a1 = new ScoredAggregate(1L, 10, 5, 2, 10*1 + 5*2 + 2*5);
+        ScoredAggregate a2 = new ScoredAggregate(2L, 3, 1, 1, 3*1 + 1*2 + 1*5);
+
+        writer.beforeStep(null);
+
+        // when
+        writer.write(Chunk.of(a1, a2));
+        writer.afterStep(null);
+
+        // then
+        verify(weeklyRepository, times(1))
+                .bulkUpsert(any(LocalDate.class), any(LocalDate.class), anyList());
+        verify(weeklyRepository, times(1))
+                .refreshRanks(any(LocalDate.class));
+    }
+
+    @Test
+    void writer_does_not_call_repository_when_buffer_is_empty() {
+        // given
+        writer.beforeStep(null);
+
+        // when
+        writer.afterStep(null);
+
+        // then
+        verify(weeklyRepository, never()).bulkUpsert(any(), any(), anyList());
+        verify(weeklyRepository, never()).refreshRanks(any());
+    }
+}

--- a/apps/commerce-batch/src/test/java/com/loopers/infrastructure/job/MetricAggregationJobConfigTest.java
+++ b/apps/commerce-batch/src/test/java/com/loopers/infrastructure/job/MetricAggregationJobConfigTest.java
@@ -1,0 +1,84 @@
+package com.loopers.infrastructure.job;
+
+
+import com.loopers.domain.metric.ProductMetricDailyModel;
+import com.loopers.domain.metric.ProductMetricMonthlyModel;
+import com.loopers.domain.metric.ProductMetricWeeklyModel;
+import com.loopers.infrastructure.ProductMetricDailyJpaRepository;
+import com.loopers.infrastructure.ProductMetricMonthlyJpaRepository;
+import com.loopers.infrastructure.ProductMetricWeeklyJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBatchTest
+@SpringBootTest
+class MetricAggregationJobConfigTest {
+
+    @Autowired private JobLauncherTestUtils jobLauncherTestUtils;
+
+
+    @Autowired private Job metricAggregationJob;
+
+    @Autowired private ProductMetricDailyJpaRepository dailyRepo;
+    @Autowired private ProductMetricWeeklyJpaRepository weeklyRepo;
+    @Autowired private ProductMetricMonthlyJpaRepository monthlyRepo;
+
+    @BeforeEach
+    void setUp() {
+
+        weeklyRepo.deleteAll();
+        monthlyRepo.deleteAll();
+        dailyRepo.deleteAll();
+
+
+        LocalDate d1 = LocalDate.now().minusDays(1);
+        LocalDate d2 = LocalDate.now().minusDays(2);
+        dailyRepo.saveAll(List.of(
+                new ProductMetricDailyModel(1001L, d1),
+                new ProductMetricDailyModel(1002L, d1),
+                new ProductMetricDailyModel(1001L, d2)
+        ));
+    }
+
+    @Test
+    void metricAggregationJob_runs_successfully() throws Exception {
+
+        jobLauncherTestUtils.setJob(metricAggregationJob);
+
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob();
+        assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+
+        // 주간/월간 집계가 생겼는지 확인
+        List<ProductMetricWeeklyModel> weekly = weeklyRepo.findAll();
+        List<ProductMetricMonthlyModel> monthly = monthlyRepo.findAll();
+
+        assertThat(weekly).isNotEmpty();
+        assertThat(monthly).isNotEmpty();
+
+
+        assertThat(weekly).allMatch(w -> w.getScore() >= 0);
+        assertThat(weekly).allMatch(w -> w.getRankValue() > 0);
+    }
+
+    @Test
+    void weeklyStep_runs_successfully() throws Exception {
+
+        JobExecution jobExecution = jobLauncherTestUtils.launchStep("weeklyStep");
+        assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+
+        List<ProductMetricWeeklyModel> weekly = weeklyRepo.findAll();
+        assertThat(weekly).isNotEmpty();
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/ConsumerGroupConfig.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/ConsumerGroupConfig.java
@@ -1,4 +1,4 @@
-package com.loopers.config;
+package com.loopers.application;
 
 
 import org.apache.kafka.common.TopicPartition;

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankValue.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankValue.java
@@ -1,0 +1,11 @@
+package com.loopers.application.ranking;
+
+
+public record RankValue(
+        Long productId,
+        Long likeCount,
+        Long saleCount,
+        Long viewCount
+){
+
+}

--- a/apps/commerce-streamer/src/main/resources/application.yml
+++ b/apps/commerce-streamer/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   main:
     web-application-type: servlet
   application:
-    name: commerce-api
+    name: commerce-streamer
   profiles:
     active: local
   config:

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/web/WebMvcConfig.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/web/WebMvcConfig.kt
@@ -1,4 +1,4 @@
-package com.loopers.config.web
+package com.loopers.application.web
 
 import com.loopers.interfaces.api.argumentresolver.UserInfoArgumentResolver
 import org.springframework.context.annotation.Configuration

--- a/modules/jpa/src/main/java/com/loopers/application/jpa/DataSourceConfig.java
+++ b/modules/jpa/src/main/java/com/loopers/application/jpa/DataSourceConfig.java
@@ -1,4 +1,4 @@
-package com.loopers.config.jpa;
+package com.loopers.application.jpa;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;

--- a/modules/jpa/src/main/java/com/loopers/application/jpa/JpaConfig.java
+++ b/modules/jpa/src/main/java/com/loopers/application/jpa/JpaConfig.java
@@ -1,4 +1,4 @@
-package com.loopers.config.jpa;
+package com.loopers.application.jpa;
 
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Configuration;

--- a/modules/jpa/src/main/java/com/loopers/application/jpa/QueryDslConfig.java
+++ b/modules/jpa/src/main/java/com/loopers/application/jpa/QueryDslConfig.java
@@ -1,4 +1,4 @@
-package com.loopers.config.jpa;
+package com.loopers.application.jpa;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ include(
     ":apps:commerce-api",
     ":apps:pg-simulator",
     ":apps:commerce-streamer",
+    ":apps:commerce-batch",
     ":modules:jpa",
     ":modules:redis",
     ":modules:kafka",

--- a/supports/jackson/src/main/java/com/loopers/application/jackson/JacksonConfig.java
+++ b/supports/jackson/src/main/java/com/loopers/application/jackson/JacksonConfig.java
@@ -1,4 +1,4 @@
-package com.loopers.config.jackson;
+package com.loopers.application.jackson;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonGenerator;


### PR DESCRIPTION
## 📌 Summary
 대규모 데이터 집계 및 조회 전용 구조에 대한 설계를 진행
Spring Batch 를 이용해 주간, 월간 랭킹을 구현

## 💬 Review Points

### 🟢 배치는 JdbcTemplate vs PA Repository

[feat : 일간, 주간 배치 구현](https://github.com/simbokyung98/loopers-ecommerce-system/pull/37/commits/203a848a1aa502c2b3e926b149567f89f7dcc05c)

배치 쿼리를 구성할 때 JdbcTemplate 와 JPA Repository 을 혼용하여 사용하였습니다.
Reader 단계에서는 대량 데이터를 집계해야 해서 JdbcTemplate으로 직접 SQL을 실행했습니다.
Writer 단계에서는 집계된 결과를 엔티티와 연결된 테이블에 반영해야 했기 때문에, JPA Repository를 통해 업데이트 쿼리를 실행했습니다.

👉 리뷰 받고 싶은 부분: 배치 전 과정에서 한가지 규칙으로 일관성을 유지하는 편이 더 바람직한지 멘토님의 의견이 듣고 싶습니다.

--- 

### 🟡 랭킹 적제 저장소는 어디로 해야할까

[feat : 일간, 주간 배치 구현](https://github.com/simbokyung98/loopers-ecommerce-system/pull/37/commits/203a848a1aa502c2b3e926b149567f89f7dcc05c)

이번 배치에서는 랭킹 적제를 DB에 반영하는 방식으로 구현했습니다.
하지만 고민되는 부분은, 랭킹 적제라는 특성상 DB보다 Redis ZSET이 더 적합하지 않았을까? 하는 점입니다.

기존에는 카프카 이벤트를 소비하면서 DB에 집계 테이블을 쌓고, 동시에 Redis ZSET에도 랭킹 연산을 반영하는 방식을 사용했습니다.

그렇다면 이번 주/월간 배치도 단순히 DB에 적재하는 것보다,
집계 테이블 저장 + Redis ZSET 랭킹 연산을 배치 안에서 같이 처리하는 게 더 일관된 구조가 아닐까 고민됩니다.

👉 리뷰 받고 싶은 부분: 멘토님은 실무에서 랭킹 적제를 DB로만 관리하는 것이 맞다고 보시는지, 아니면 Redis 같은 캐시형 스토어를 1차 저장소로 적극적으로 활용하는 쪽을 선호하시는지 궁금합니다.

--- 

10주 동안 정성스러운 멘토링과 피드백을 진행해 주셔서 감사합니다.
매주 과제를 하면서 기술적인 고민뿐만 아니라, 문제를 바라보는 시각과 선택의 기준까지 많이 배울 수 있었습니다.

이번 과정을 통해 제 부족한 부분을 많이 확인할 수 있었고, 동시에 성장할 수 있는 방향도 분명히 보였습니다.
앞으로도 배운 내용을 실무에 적용하면서, 더 단단한 개발자로 성장해 나가겠습니다.

다시 한 번 감사드립니다. 🙏

## ✅ Checklist
- [x] #38 
- [x] #39  

